### PR TITLE
fix(deploy): Add passphrase to SSH and SCP actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,7 @@ jobs:
                   username: ${{ secrets.SSH_USER }}
                   key: ${{ secrets.SSH_KEY }}
                   port: ${{ secrets.SSH_PORT }}
+                  passphrase: ${{ secrets.SSH_PASSPHRASE }}
                   source: "release.tar.gz"
                   target: "~/deploy"
 
@@ -81,6 +82,7 @@ jobs:
                   username: ${{ secrets.SSH_USER }}
                   key: ${{ secrets.SSH_KEY }}
                   port: ${{ secrets.SSH_PORT }}
+                  passphrase: ${{ secrets.SSH_PASSPHRASE }}
                   script: |
                       set -euo pipefail
                       DEPLOY_PATH=${{ secrets.DEPLOY_PATH }}


### PR DESCRIPTION
The deployment was failing because the SSH key is protected by a passphrase. This change adds the 'passphrase' parameter to the scp and ssh steps in the GitHub Actions workflow to allow authentication.